### PR TITLE
Implement JSON output

### DIFF
--- a/Portscout/SQL.pm
+++ b/Portscout/SQL.pm
@@ -231,7 +231,7 @@ $sql{portdata_uncheck} =
 
 #$sql{portdata_genresults}
 
-$sql{portdata_selectall} =
+$sql{portdata_selectmaintainer} =
 	q(SELECT *
 	    FROM portdata
 	   WHERE lower(maintainer) = lower(?)

--- a/Portscout/SQL.pm
+++ b/Portscout/SQL.pm
@@ -231,6 +231,12 @@ $sql{portdata_uncheck} =
 
 #$sql{portdata_genresults}
 
+$sql{portdata_selectall} =
+	q(SELECT *
+	    FROM portdata
+	   WHERE moved != true
+	ORDER BY cat,name);
+
 $sql{portdata_selectmaintainer} =
 	q(SELECT *
 	    FROM portdata

--- a/portscout.pl
+++ b/portscout.pl
@@ -1245,7 +1245,7 @@ sub GenerateHTML
 	$dbh = connect_db();
 
 	prepare_sql($dbh, \%sths,
-		qw(portdata_genresults portdata_selectall portdata_selectall_limited)
+		qw(portdata_genresults portdata_selectmaintainer portdata_selectall_limited)
 	);
 
 	if ($Portscout::SQL::sql{portdata_genresults_init}) {
@@ -1323,8 +1323,8 @@ sub GenerateHTML
 		$outdata{maintainer} = $addr;
 		$template->applyglobal(\%outdata);
 
-		$sths{portdata_selectall}->execute($addr);
-		while (my $row = $sths{portdata_selectall}->fetchrow_hashref) {
+		$sths{portdata_selectmaintainer}->execute($addr);
+		while (my $row = $sths{portdata_selectmaintainer}->fetchrow_hashref) {
 			if ($row->{ignore}) {
 				$row->{method} = 'X';
 				$row->{newver} = '';

--- a/portscout.pl
+++ b/portscout.pl
@@ -45,6 +45,7 @@ use LWP::UserAgent;
 use MIME::Lite;
 use Net::FTP;
 use URI;
+use JSON;
 
 use DBI;
 
@@ -1245,7 +1246,7 @@ sub GenerateHTML
 	$dbh = connect_db();
 
 	prepare_sql($dbh, \%sths,
-		qw(portdata_genresults portdata_selectmaintainer portdata_selectall_limited)
+		qw(portdata_genresults portdata_selectall portdata_selectmaintainer portdata_selectall_limited)
 	);
 
 	if ($Portscout::SQL::sql{portdata_genresults_init}) {
@@ -1376,6 +1377,49 @@ sub GenerateHTML
 	}
 
 	$template->output('restricted-ports.html');
+
+	print "Creating JSON dump of all data...\n";
+
+	open my $jf, '>', $settings{html_data_dir} . '/dump.json'
+		or die 'Cannot open JSON output';
+
+	print $jf '[';
+
+	my $firstitem = 1;
+
+	$sths{portdata_selectall}->execute();
+	while (my $row = $sths{portdata_selectall}->fetchrow_hashref) {
+		if ($row->{ignore}) {
+			$row->{method} = 'X';
+			$row->{newver} = '';
+			$row->{newurl} = '';
+		} else {
+			if ($row->{method} == METHOD_LIST) {
+				$row->{method} = 'L';
+			} elsif ($row->{method} == METHOD_GUESS) {
+				$row->{method} = 'G';
+			} else {
+				$row->{method} = '';
+			}
+		}
+
+		if ($row->{newver} && ($row->{ver} ne $row->{newver})) {
+			$row->{newdistfile} = 'updated';
+		} else {
+			next if ($settings{hide_unchanged});
+			$row->{newdistfile} = '';
+		}
+		$row->{updated} =~ s/:\d\d(?:\.\d+)?$/ $settings{local_timezone}/;
+		$row->{checked} =~ s/:\d\d(?:\.\d+)?$/ $settings{local_timezone}/;
+
+		$row = { map { $_ => $row->{$_} } qw(name cat maintainer ver method newver newurl checked updated discovered) };
+
+		print $jf ',' unless $firstitem;
+		print $jf encode_json($row);
+		$firstitem = 0;
+	}
+	print $jf ']';
+	close $jf;
 
 	finish_sql($dbh, \%sths);
 	$dbh->disconnect;

--- a/portscout.pod
+++ b/portscout.pod
@@ -45,6 +45,7 @@ Plus we need a few Perl modules:
     - MIME::Lite
     - XML::XPath
     - XML::XPath::XMLParser
+    - JSON
 
 SQLite support is currently limited to non-forking mode only. That is, if you
 decide to use SQLite, Portscout will only check one port at a time; this will


### PR DESCRIPTION
As discussed via email in June, implement a JSON dump of portscount status for all ports.
This allows to use portscount data in other projects and tools, such as [Repology](https://repology.org).