### PR TITLE
Add custom email message for ports with no maintainer

### DIFF
--- a/Portscout/Config.pm
+++ b/Portscout/Config.pm
@@ -104,6 +104,7 @@ my (@paths, %settings_types, $bool_opts);
 	mail_enable     	=> 1,
 	mail_from       	=> APPNAME,
 	mail_subject    	=> '',
+	mail_altsubject    	=> '',
 	mail_method     	=> 'sendmail',
 	mail_host       	=> 'localhost',
 

--- a/Portscout/Config.pm
+++ b/Portscout/Config.pm
@@ -103,8 +103,8 @@ my (@paths, %settings_types, $bool_opts);
 
 	mail_enable     	=> 1,
 	mail_from       	=> APPNAME,
-	mail_subject    	=> '',
-	mail_altsubject    	=> '',
+	mail_subject    	=> 'FreeBSD ports you maintain which are out of date',
+	mail_altsubject    	=> 'Unmaintained FreeBSD ports which are out of date',
 	mail_method     	=> 'sendmail',
 	mail_host       	=> 'localhost',
 

--- a/portscout.conf
+++ b/portscout.conf
@@ -87,6 +87,7 @@ mail enable      = true
 
 mail from        = portscout 				# Sender address
 mail subject     = FreeBSD ports you maintain which are out of date
+mail altsubject  = Unmaintained FreeBSD ports which are out of date
 mail method      = sendmail  				# Can be 'sendmail' or 'smtp'
 #mail host        = localhost				# SMTP server, if method is 'smtp'
 

--- a/templates/reminder-no-maintainer.mail
+++ b/templates/reminder-no-maintainer.mail
@@ -1,0 +1,28 @@
+Dear port maintainers,
+
+The portscout new distfile checker has detected that one or more unmaintained 
+ports appears to be out of date. Please take the opportunity to check each of the 
+ports listed below, and if possible and appropriate, submit/commit an update. 
+Please consider also adopting this port. If any ports have already been updated, 
+you can safely ignore the entry.
+
+An e-mail will not be sent again for any of the port/version combinations
+below.
+
+Full details can be found at the following URL:
+http://beta.inerd.com/portscout/%%(maintainer).html
+
+
+Port                                            | Current version | New version
+------------------------------------------------+-----------------+------------
+%%:%%(cat_portname:47) | %%(ver:16)| %%(newver)
+%%:------------------------------------------------+-----------------+------------
+
+
+If any of the above results are invalid, please check the following page
+for details on how to improve portscout's detection and selection of
+distfiles on a per-port basis:
+
+http://beta.inerd.com/portscout-portconfig.txt
+
+Thanks.


### PR DESCRIPTION
The motivation behind this change should be pretty clear; when `portscout` sends an email to a port maintainer, it should check whether that "maintainer" is `ports@freebsd.org` and if so send a special e-mail. I made a new template for that `reminder-no-maintainer.mail` for that purpose, please tell me if it requires any changes. Also let me know if there are any other issues I overlooked.

EDIT: Yes, in fact, I did overlook something: The subject line is the same. I'll get on that too. 

EDIT2: Made those changes too. Added another config option `mail altsubject` to `portscout.conf`. The alternate subject line is now `Unmaintained FreeBSD ports which are out of date`.