### PR TITLE
Add an URL parameter to activate the outdated checkbox

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -101,6 +101,19 @@
 	<input type="button" value="Apply" id="submitbutton" onclick="FilterResults()" />
 </span>
 
+<script>
+	const queryString = window.location.search;
+	const urlParams = new URLSearchParams(queryString);
+	const outdatedParam = urlParams.get('outdated');
+	if (outdatedParam === '1') {
+		document.getElementById('filter_ood').checked = true;
+		FilterResults();
+	} else if (outdatedParam === '0') {
+		document.getElementById('filter_ood').checked = false;
+		FilterResults();
+	}
+</script>
+
 <br /><br />
 
 <table class="results" cellspacing="1" cellpadding="2">

--- a/templates/maintainer.html
+++ b/templates/maintainer.html
@@ -115,6 +115,19 @@
 	<input type="button" value="Apply" id="submitbutton" onclick="FilterResults()" />
 </span>
 
+<script>
+	const queryString = window.location.search;
+	const urlParams = new URLSearchParams(queryString);
+	const outdatedParam = urlParams.get('outdated');
+	if (outdatedParam === '1') {
+		document.getElementById('filter_ood').checked = true;
+		FilterResults();
+	} else if (outdatedParam === '0') {
+		document.getElementById('filter_ood').checked = false;
+		FilterResults();
+	}
+</script>
+
 <br /><br />
 
 <table class="results" cellspacing="1" cellpadding="2">


### PR DESCRIPTION
I've added the option to specify an URL parameter (outdated=1) in order to activate the outdated checkbox.

This makes it possible to bookmark your ports and have it already filtered to the outdated ports.

While here, I've also added it to the 'index view':

For instance:
* Maintainer view - https://portscout.freebsd.org/ehaupt@freebsd.org.html?outdated=1
* Index view - https://portscout.freebsd.org/?outdated=1