### PR TITLE
Improve version guessing by considering versions with more parts

### DIFF
--- a/Portscout/Util.pm
+++ b/Portscout/Util.pm
@@ -265,6 +265,13 @@ sub verguess
 		push @ver_guesses, $guess;
 	}
 
+	# for versions in the format N.N try N.N.N, and for N.N.N try N.N.N.N
+	if ($#vparts == 2 or $#vparts == 3) {
+		for my $n (1..4) {
+			push @ver_guesses, $ver . "." . $n;
+		}
+	}
+
 	return @ver_guesses;
 }
 


### PR DESCRIPTION
The attached patch would make portscout to successfully guess version when it is increased for example from 1.7 to 1.7.1