### PR TITLE
docs: fix duplicated word in comment

### DIFF
--- a/Portscout/SiteHandler/GitHub.pm
+++ b/Portscout/SiteHandler/GitHub.pm
@@ -120,7 +120,7 @@ sub GetFiles
 		}
 	}
 
-	# In case there aren't any releases, try tags tags instead
+	# In case there aren't any releases, try tags instead
 	if (scalar @$files == $files_count_before) {
 		my $tags = _call_github_api('/repos/' . $projname . '/tags')
 		  or return 0;


### PR DESCRIPTION
## Summary

Fix duplicated word in `Portscout/SiteHandler/GitHub.pm`:
- `try tags tags instead` → `try tags instead`

No functional changes — comment only.